### PR TITLE
Shallow checkout of watchman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,8 @@ RUN \
 # fs.inotify.max_user_watches value so that watchman will 
 # work better with ember projects.
 RUN \
-	git clone https://github.com/facebook/watchman.git &&\
+	git clone --branch v4.9.0 --depth 1 https://github.com/facebook/watchman.git &&\
 	cd watchman &&\
-	git checkout v4.7.0 &&\
 	./autogen.sh &&\
 	./configure &&\
 	make &&\


### PR DESCRIPTION
## Why

Instead of checking out the full dev tree, just check out the latest watchman release. This will make the checkout phase much quicker.

## Changes

* Checkout the latest v4.9.0 (instead of v4.7.0)
* Skip the rest of the source tree checkout.